### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FacebookSearch
-[![Build](https://api.travis-ci.org/ckoepp/FacebookSearch.png?branch=master)](https://travis-ci.org/ckoepp/FacebookSearch/branches) [![Downloads](https://pypip.in/d/FacebookSearch/badge.png)](https://crate.io/packages/FacebookSearch/) [![PyPI version](https://pypip.in/v/FacebookSearch/badge.png)](https://crate.io/packages/FacebookSearch/)
+[![Build](https://api.travis-ci.org/ckoepp/FacebookSearch.png?branch=master)](https://travis-ci.org/ckoepp/FacebookSearch/branches) [![Downloads](https://img.shields.io/pypi/dm/FacebookSearch.svg)](https://crate.io/packages/FacebookSearch/) [![PyPI version](https://img.shields.io/pypi/v/FacebookSearch.svg)](https://crate.io/packages/FacebookSearch/)
 
 This library is in a very early stage of development and due to this there no documentation available (besides the source itself :p).
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20facebooksearch))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `facebooksearch`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.